### PR TITLE
Replace all `system` calls with fork+exec schema

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -20,4 +20,4 @@ jobs:
         sudo apt-get install -y valgrind
     - name: Valgrind
       run: |
-        sudo valgrind --error-exitcode=1 --leak-check=full ./cmake/yfc tests/sem/funcs-pass.yf
+        sudo valgrind --error-exitcode=1 --leak-check=full ./cmake/yfc tests/sem/funcs-pass.yf --just-semantics

--- a/src/driver/args.c
+++ b/src/driver/args.c
@@ -194,6 +194,11 @@ void yf_parse_args(int argc, char ** argv, struct yf_args * args) {
             continue;
         }
 
+        if (STREQ(arg, "--dump-commands")) {
+            args->dump_commands = 1;
+            continue;
+        }
+
         /* No other options are known. Yet. */
         if (arg[0] == '-') {
             yf_set_error(args);

--- a/src/driver/args.c
+++ b/src/driver/args.c
@@ -63,6 +63,7 @@ void yf_parse_args(int argc, char ** argv, struct yf_args * args) {
     
     /* If the next option we're parsing is the native C compiler name */
     bool want_compiler_name = false;
+    bool want_compiler_type = false;
 
     /* Zero the args structure. */
     memset(args, 0, sizeof *args);
@@ -91,6 +92,27 @@ void yf_parse_args(int argc, char ** argv, struct yf_args * args) {
             continue;
         }
 
+        if (want_compiler_type) {
+            want_compiler_type = false;
+            if (args->compiler_class == YF_COMPILER_UNKNOWN) {
+                if (STREQ(arg, "gcc")) {
+                    args->compiler_class = YF_COMPILER_GCC;
+                }
+                else if (STREQ(arg, "msvc")) {
+                    args->compiler_class = YF_COMPILER_MSVC;
+                }
+                else {
+                    /* Invalid compiler type */
+                    yf_set_error(args);
+                }
+            } else {
+                /* Name has already been set */
+                yf_set_error(args);
+                return;
+            }
+            continue;
+        }
+
         if (STREQ(arg, "-h") || STREQ(arg, "--help")) {
             yf_check_action(args, YF_HELP);
             continue;
@@ -104,6 +126,15 @@ void yf_parse_args(int argc, char ** argv, struct yf_args * args) {
         if (STREQ(arg, "-native-compiler")) {
             want_compiler_name = true;
             /* Make sure there actually is a compiler to parse after */
+            if (i + 1 == argc) {
+                yf_set_error(args);
+                return;
+            }
+            continue;
+        }
+
+        if (STREQ(arg, "-compiler-type")) {
+            want_compiler_type = true;
             if (i + 1 == argc) {
                 yf_set_error(args);
                 return;

--- a/src/driver/args.h
+++ b/src/driver/args.h
@@ -18,6 +18,12 @@ enum yf_info_output {
     YF_ERROR_NO_ARGS, /* SPECIFICALLY if no arguments are given. */
 };
 
+enum yf_compiler_class {
+    YF_COMPILER_UNKNOWN,
+    YF_COMPILER_GCC, // A gcc-like compiler
+    YF_COMPILER_MSVC, // MS Visual C compiler (unsupported)
+};
+
 struct yf_args {
     
     /**
@@ -37,6 +43,12 @@ struct yf_args {
      * Set to NULL if none is specified.
      */
     const char * compiler;
+
+    /**
+     * Compiler chosen by the frontend
+     */
+    const char * selected_compiler;
+    enum yf_compiler_class compiler_class;
 
     /**
      * The indiviidual files to compile, as well as how many files.

--- a/src/driver/args.h
+++ b/src/driver/args.h
@@ -87,6 +87,11 @@ struct yf_args {
      */
     bool dump_projfiles;
 
+    /**
+     * Should we be dumping compiler invocations?
+     */
+    bool dump_commands;
+
 };
 
 /**

--- a/src/driver/c-compiler.h
+++ b/src/driver/c-compiler.h
@@ -7,16 +7,11 @@
 
 #include <driver/args.h>
 
-/**
- * An access to the compiler used to compile the generated C code.
- */
-extern char YF_C_COMPILER[256];
-
 enum yf_c_compiler_status {
     YF_COMPILER_OK,
     YF_SPECIFIED_COMPILER_NOT_FOUND,
     YF_NO_COMPILER_FOUND,
-    YF_COMPILER_NAME_OVERFLOW,
+    YF_COMPILER_NO_CLASS,
 };
 
 /**

--- a/src/driver/compile.c
+++ b/src/driver/compile.c
@@ -132,7 +132,7 @@ static int yf_run_compiler_on_data(
     /* Finally, generate code. */
     if (!args->just_semantics) {
         BEGIN_PROFILE();
-        yf_run_backend(data, args);
+        err = yf_run_backend(data, args);
         gettimeofday(&step_end, NULL);
         END_PROFILE("generating code");
     }

--- a/src/driver/compiler-backend.c
+++ b/src/driver/compiler-backend.c
@@ -1,4 +1,6 @@
 #include "compiler-backend.h"
+#include "driver/os.h"
+#include "util/list.h"
 
 #include <string.h>
 
@@ -6,6 +8,25 @@
 #include <gen/gen.h>
 #include <util/allocator.h>
 #include <util/yfc-out.h>
+
+#define DUMP_COMMANDS 1
+
+#if DUMP_COMMANDS
+static void dump_command(const char * const cmd[]) {
+    if (*cmd) {
+        fputc('"', YF_OUTPUT_STREAM);
+        fputs(*cmd, YF_OUTPUT_STREAM);
+        fputc('"', YF_OUTPUT_STREAM);
+        for (++cmd; *cmd; ++cmd) {
+            fputc(' ', YF_OUTPUT_STREAM);
+            fputc('"', YF_OUTPUT_STREAM);
+            fputs(*cmd, YF_OUTPUT_STREAM);
+            fputc('"', YF_OUTPUT_STREAM);
+        }
+    }
+    fputc('\n', YF_OUTPUT_STREAM);
+}
+#endif
 
 int create_output_file_name(
     struct yf_file_compilation_data * data, struct yf_args * args
@@ -75,52 +96,101 @@ int yf_run_c_backend(
 
     int i;
     struct yf_file_compilation_data * file;
-    
-    /* Where gcc -c foo.c -o foo.o is stored */
-    char * compile_buf = yf_malloc(256 * sizeof (char));
-    /* Where gcc foo1.o foo2.o -o foo is stored */
-    char * link_buf = yf_malloc(16384 * sizeof (char));
-    if (!compile_buf || !link_buf)
-        return 1;
 
-    if (yf_determine_c_compiler(args) != YF_COMPILER_OK) {
-        YF_PRINT_ERROR("could not determine C compiler");
+    switch (yf_determine_c_compiler(args)) {
+        case YF_COMPILER_OK:
+            break;
+        case YF_SPECIFIED_COMPILER_NOT_FOUND:
+            YF_PRINT_ERROR("specified C compiler not found");
+            return 1;
+        case YF_NO_COMPILER_FOUND:
+            YF_PRINT_ERROR("could not determine C compiler");
+            return 1;
+        case YF_COMPILER_NO_CLASS:
+            YF_PRINT_ERROR("cannot set compiler type without providing compiler path");
+            return 1;
+    }
+
+    if (args->compiler_class != YF_COMPILER_GCC) {
+        YF_PRINT_ERROR("only gcc-like compilers are supported");
         return 1;
     }
 
-    strcpy(link_buf, YF_C_COMPILER);
-    strcat(link_buf, " ");
+    const file_open_descriptor descs[] = {
+        { 0, YF_OS_FILE_DEVNULL },
+        { 1, YF_OS_FILE_DEVNULL },
+        { 2, YF_OS_FILE_DEVNULL },
+        { -1, -1 },
+    };
+
+    /* Where gcc -c foo.c -o foo.o is stored */
+    const char * compile_cmd[] = { args->selected_compiler, "-c", NULL, "-o", NULL, NULL };
+    /* Where gcc foo1.o foo2.o -o foo is stored */
+    const char ** link_cmd;
+    struct yf_list link_objs;
+    yf_list_init(&link_objs);
+
+    size_t num_objs = 0;
 
     for (i = 0; i < YFH_BUCKETS; ++i) {
         file = data->files->buckets[i].value;
         if (!file) continue;
+
+        /* Rewite file name foo.c to have foo.o */
+        size_t fname_len = strlen(file->output_file);
+        char * object_file = yf_malloc(fname_len + 1);
+        memcpy(object_file, file->output_file, fname_len + 1);
+        object_file[fname_len - 1] = 'o';
+
         /* Run compiler */
-        sprintf(
-            compile_buf,
-            "%s -c %s -o %s",
-            YF_C_COMPILER, file->output_file, file->output_file
-        );
-        /* Now, rewrite gcc -c x.c -o x.c  to have x.o */
-        strcpy(compile_buf + strlen(compile_buf) - 2, ".o");
-        //system(compile_buf);
-        /* Also append name to linker command */
-        strcat(link_buf, file->output_file);
-        strcpy(link_buf + strlen(link_buf) - 2, ".o");
-        strcat(link_buf, " ");
+        /* <file-name> */ compile_cmd[2] = file->output_file;
+        /* -o <output-name> */ compile_cmd[4] = object_file;
+
+        #if DUMP_COMMANDS
+        fputs("Compile command: ", YF_OUTPUT_STREAM);
+        dump_command(compile_cmd);
+        proc_exec(compile_cmd, descs, 0);
+        #endif
+
+        /*
+        Also append name to linker command.
+        File name will be automatically freed on list destroy.
+        */
+        yf_list_add(&link_objs, object_file);
+        ++num_objs;
+    }
+
+    /* <compiler> <objects...> -o <executable> */
+    link_cmd = yf_malloc((4 + num_objs) * sizeof(const char *));
+
+    link_cmd[0] = args->selected_compiler;
+    const char ** it = link_cmd + 1;
+    size_t obj_it;
+    for (obj_it = 0; obj_it < num_objs; ++obj_it) {
+        yf_list_get(&link_objs, (void **)it);
+        yf_list_next(&link_objs);
+        ++it;
     }
 
     /* Finally, add -o output_file */
+    *it++ = "-o";
     if (args->project) {
-        strcat(link_buf, "-o ");
-        strcat(link_buf, data->project_name);
+        *it++ = data->project_name;
     } else {
-        strcat(link_buf, "-o a.out");
+        *it++ = "a.out";
     }
 
-    //system(link_buf);
+    /* Finish argument list */
+    *it = NULL;
 
-    free(compile_buf);
-    free(link_buf);
+    #if DUMP_COMMANDS
+    fputs("Link command: ", YF_OUTPUT_STREAM);
+    dump_command(link_cmd);
+    proc_exec(link_cmd, descs, 0);
+    #endif
+
+    yf_free(link_cmd);
+    yf_list_destroy(&link_objs, true);
 
     return 0;
 

--- a/src/driver/compiler-backend.c
+++ b/src/driver/compiler-backend.c
@@ -188,13 +188,19 @@ int yf_run_c_backend(
     }
     if (proc_exec(link_cmd, descs, 0) != 0) {
         YF_PRINT_ERROR("Linking of project failed");
-        return 2;
+        goto err2;
     }
 
+    int ret = 0;
+    goto out;
+
+err2:
+    ret = 2;
     yf_free(link_cmd);
     yf_list_destroy(&link_objs, true);
 
-    return 0;
+out:
+    return ret;
 
 }
 

--- a/src/driver/compiler-backend.c
+++ b/src/driver/compiler-backend.c
@@ -9,7 +9,7 @@
 #include <util/allocator.h>
 #include <util/yfc-out.h>
 
-#define DUMP_COMMANDS 1
+#define DUMP_COMMANDS 0
 
 #if DUMP_COMMANDS
 static void dump_command(const char * const cmd[]) {
@@ -116,7 +116,7 @@ int yf_run_c_backend(
         return 1;
     }
 
-    const file_open_descriptor descs[] = {
+    static const file_open_descriptor descs[] = {
         { 0, YF_OS_FILE_DEVNULL },
         { 1, YF_OS_FILE_DEVNULL },
         { 2, YF_OS_FILE_DEVNULL },
@@ -149,8 +149,8 @@ int yf_run_c_backend(
         #if DUMP_COMMANDS
         fputs("Compile command: ", YF_OUTPUT_STREAM);
         dump_command(compile_cmd);
-        proc_exec(compile_cmd, descs, 0);
         #endif
+        proc_exec(compile_cmd, descs, 0);
 
         /*
         Also append name to linker command.
@@ -186,8 +186,8 @@ int yf_run_c_backend(
     #if DUMP_COMMANDS
     fputs("Link command: ", YF_OUTPUT_STREAM);
     dump_command(link_cmd);
-    proc_exec(link_cmd, descs, 0);
     #endif
+    proc_exec(link_cmd, descs, 0);
 
     yf_free(link_cmd);
     yf_list_destroy(&link_objs, true);

--- a/src/driver/compiler-backend.c
+++ b/src/driver/compiler-backend.c
@@ -182,24 +182,21 @@ int yf_run_c_backend(
     /* Finish argument list */
     *it = NULL;
 
+    /* Return value */
+    int ret = 0;
+
     if (args->dump_commands) {
         fputs("Link command: ", YF_OUTPUT_STREAM);
         dump_command(link_cmd);
     }
     if (proc_exec(link_cmd, descs, 0) != 0) {
         YF_PRINT_ERROR("Linking of project failed");
-        goto err2;
+        ret = 2;
     }
 
-    int ret = 0;
-    goto out;
-
-err2:
-    ret = 2;
     yf_free(link_cmd);
     yf_list_destroy(&link_objs, true);
 
-out:
     return ret;
 
 }

--- a/src/driver/compiler-backend.c
+++ b/src/driver/compiler-backend.c
@@ -9,9 +9,6 @@
 #include <util/allocator.h>
 #include <util/yfc-out.h>
 
-#define DUMP_COMMANDS 0
-
-#if DUMP_COMMANDS
 static void dump_command(const char * const cmd[]) {
     if (*cmd) {
         fputc('"', YF_OUTPUT_STREAM);
@@ -26,7 +23,6 @@ static void dump_command(const char * const cmd[]) {
     }
     fputc('\n', YF_OUTPUT_STREAM);
 }
-#endif
 
 int create_output_file_name(
     struct yf_file_compilation_data * data, struct yf_args * args
@@ -146,10 +142,10 @@ int yf_run_c_backend(
         /* <file-name> */ compile_cmd[2] = file->output_file;
         /* -o <output-name> */ compile_cmd[4] = object_file;
 
-        #if DUMP_COMMANDS
-        fputs("Compile command: ", YF_OUTPUT_STREAM);
-        dump_command(compile_cmd);
-        #endif
+        if (args->dump_commands) {
+            fputs("Compile command: ", YF_OUTPUT_STREAM);
+            dump_command(compile_cmd);
+        }
         proc_exec(compile_cmd, descs, 0);
 
         /*
@@ -183,10 +179,10 @@ int yf_run_c_backend(
     /* Finish argument list */
     *it = NULL;
 
-    #if DUMP_COMMANDS
-    fputs("Link command: ", YF_OUTPUT_STREAM);
-    dump_command(link_cmd);
-    #endif
+    if (args->dump_commands) {
+        fputs("Link command: ", YF_OUTPUT_STREAM);
+        dump_command(link_cmd);
+    }
     proc_exec(link_cmd, descs, 0);
 
     yf_free(link_cmd);

--- a/src/driver/compiler-backend.c
+++ b/src/driver/compiler-backend.c
@@ -146,7 +146,10 @@ int yf_run_c_backend(
             fputs("Compile command: ", YF_OUTPUT_STREAM);
             dump_command(compile_cmd);
         }
-        proc_exec(compile_cmd, descs, 0);
+        if (proc_exec(compile_cmd, descs, 0) != 0) {
+            YF_PRINT_ERROR("Compilation of generated C of file %s failed", file->file_name);
+            return 2;
+        }
 
         /*
         Also append name to linker command.
@@ -183,7 +186,10 @@ int yf_run_c_backend(
         fputs("Link command: ", YF_OUTPUT_STREAM);
         dump_command(link_cmd);
     }
-    proc_exec(link_cmd, descs, 0);
+    if (proc_exec(link_cmd, descs, 0) != 0) {
+        YF_PRINT_ERROR("Linking of project failed");
+        return 2;
+    }
 
     yf_free(link_cmd);
     yf_list_destroy(&link_objs, true);
@@ -214,8 +220,8 @@ int yf_run_backend(
     }
 
     if (!err)
-        yf_run_c_backend(data, args);
+        err = yf_run_c_backend(data, args);
 
-    return 0;
+    return err;
 
 }

--- a/src/driver/help.c
+++ b/src/driver/help.c
@@ -6,6 +6,7 @@ const char
       "-h, --help: Display this message.\n"
       "-v, --version: Display version.\n"
       "-native-compiler <compiler>: specify the native C compiler to use.\n"
+      "-compiler-type gcc|msvc: specify the class of a native C compiler. (default: gcc)\n"
       "yfc <file1> <file2> ...: compile and link the given files, up to 16.\n"
       "--project: Compile all files in src/ that need to be compiled. "
       "Read documentation for more specifics on this flag.\n"

--- a/src/driver/help.c
+++ b/src/driver/help.c
@@ -14,7 +14,8 @@ const char
       "--dump-cst: Test parser by printing out the CST.\n"
       "--just-semantics: Only verify the code, do not generate it.\n"
       "--benchmark: Print out time taken for each step.\n"
-      "--dump-projfiles: Print out all files in a project.\n",
+      "--dump-projfiles: Print out all files in a project.\n"
+      "--dump-commands: Show all compiler invocations.\n",
     * HELP_HINT_MSG = "Invalid command. "
       "Use \"-h\" or \"--help\" for a list of possible commands.\n",
     * NO_ARGS_MSG = "yfc: Use \"-h\" or \"--help\" "

--- a/src/driver/os.c
+++ b/src/driver/os.c
@@ -24,19 +24,6 @@ int proc_exec(const char * const argv[], const file_open_descriptor descs[], int
 #include <sys/wait.h>
 #include <fcntl.h>
 
-static void closefrom_impl(int fromfd) {
-    #if YF_SUBPLATFORM == YF_PLATFORMID_LINUX || YF_SUBPLATFORM == YF_PLATFORMID_BSD
-    closefrom(fromfd);
-    #elif YF_SUBPLATFORM == YF_PLATFORMID_APPLE
-    int i, maxfd = getdtablesize();
-    for (i = fromfd; i < maxfd; ++i) {
-        close(i);
-    }
-    #else
-    #error Closefrom unsupported
-    #endif /* YF_PLATFORMID_APPLE */
-}
-
 int proc_open(process_handle * proc, const char * const argv[], const file_open_descriptor descs[], int flags) {
     pid_t child_pid = fork();
     if (child_pid == -1) {
@@ -83,7 +70,6 @@ int proc_open(process_handle * proc, const char * const argv[], const file_open_
                 dup2(fd_src, fd_dst);
             ++fd_dst;
         }
-        closefrom_impl(max_used_fd);
         if (flags & YF_OS_USE_PATH)
             execvp(argv[0], (char **)argv);
         else

--- a/src/driver/os.c
+++ b/src/driver/os.c
@@ -1,0 +1,75 @@
+#include "os.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/** TODO: Choose implementation based on platform */
+
+/** Unix implementation */
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+
+int proc_exec(const char * const argv[], const file_open_descriptor descs[], int flags) {
+    pid_t child_pid = fork();
+    if (child_pid == -1) {
+        perror("Warning: fork failed");
+        return -1;
+    } else if (child_pid == 0) {
+        int* descriptors = NULL;
+        size_t descriptors_sz = 0;
+        int nullfd = -1, maxfd = 0, max_used_fd;
+        for (file_open_descriptor const* descriptor = descs; descriptor->target_fd != -1; ++descriptor) {
+            if (descriptor->target_fd > maxfd)
+                maxfd = descriptor->target_fd;
+        }
+        max_used_fd = maxfd;
+        for (file_open_descriptor const* descriptor = descs; descriptor->target_fd != -1; ++descriptor) {
+            if (descriptor->target_fd >= (int)descriptors_sz) {
+                descriptors = realloc(descriptors, (descriptor->target_fd + 1) * sizeof(int));
+                for (; descriptors_sz < descriptor->target_fd + 1; ++descriptors_sz)
+                    descriptors[descriptors_sz] = YF_OS_FILE_CLOSED;
+            }
+            int fd = descriptor->source_fd;
+            if (fd == YF_OS_FILE_DEVNULL)
+            {
+                if (nullfd == -1)
+                {
+                    nullfd = open("/dev/null", O_RDWR);
+                    if (nullfd != -1)
+                    {
+                        dup2(nullfd, ++maxfd);
+                        nullfd = maxfd;
+                    }
+                }
+                fd = nullfd;
+            }
+            descriptors[descriptor->target_fd] = fd;
+        }
+        // TODO: Logic for keeping track of fd clobbers is too complicated for now
+        int fd_dst = 0;
+        while (fd_dst < (int)descriptors_sz) {
+            int fd_src = descriptors[fd_dst];
+            if (fd_src == YF_OS_FILE_CLOSED)
+                close(fd_dst);
+            else
+                dup2(fd_src, fd_dst);
+            ++fd_dst;
+        }
+        closefrom(max_used_fd);
+        if (flags & YF_OS_USE_PATH)
+            execvp(argv[0], (char **)argv);
+        else
+            execv(argv[0], (char **)argv);
+        perror("Process not executed");
+        abort();
+    }
+
+    int status;
+    if (waitpid(child_pid, &status, 0) == -1) {
+        perror("Warning: wait failed");
+        return -2;
+    }
+    return WEXITSTATUS(status);
+}

--- a/src/driver/os.h
+++ b/src/driver/os.h
@@ -8,10 +8,17 @@
 
 #define YF_OS_USE_PATH (1 << 0)
 
+#include <stdint.h>
+
 typedef struct {
     int target_fd;
     int source_fd; // can be OS_FILE_... constant
 } file_open_descriptor;
+
+typedef struct {
+    intptr_t pid;
+    int exit_code;
+} process_handle;
 
 /**
  * @param argv must be a NULL-terminated array of strings
@@ -20,5 +27,17 @@ typedef struct {
  * @return process exit code
  */
 int proc_exec(const char * const argv[], const file_open_descriptor descs[], int flags);
+
+/**
+ * Same as above, except it allows to explicitly wait (for instance, to allow reading from/writing to a pipe)
+ * @return 0 on success, otherwise nonzero
+ */
+int proc_open(process_handle * proc, const char * const argv[], const file_open_descriptor descs[], int flags);
+
+/**
+ * Waits for a process and saves the exit code
+ * @return 0 on success, otherwise nonzero
+ */
+int proc_wait(process_handle * proc);
 
 #endif /* DRIVER_OS_H */

--- a/src/driver/os.h
+++ b/src/driver/os.h
@@ -1,0 +1,24 @@
+/** OS interface */
+
+#ifndef DRIVER_OS_H
+#define DRIVER_OS_H
+
+#define YF_OS_FILE_CLOSED -1
+#define YF_OS_FILE_DEVNULL -2
+
+#define YF_OS_USE_PATH (1 << 0)
+
+typedef struct {
+    int target_fd;
+    int source_fd; // can be OS_FILE_... constant
+} file_open_descriptor;
+
+/**
+ * @param argv must be a NULL-terminated array of strings
+ * @param descs must be an array of descriptors terminated with a descriptor whose target_fd is -1
+ * @param flags YF_OS_USE_PATH: whether to use PATH to search for the program (if true), or to use the first argument as a file path directly (if false)
+ * @return process exit code
+ */
+int proc_exec(const char * const argv[], const file_open_descriptor descs[], int flags);
+
+#endif /* DRIVER_OS_H */

--- a/src/util/list.c
+++ b/src/util/list.c
@@ -78,7 +78,7 @@ int yf_list_add(struct yf_list * list, void * element) {
 
 void yf_list_destroy(struct yf_list * list, int free_elements) {
 
-    struct yf_list_block * block = list->current;
+    struct yf_list_block * block = list->first;
     struct yf_list_block * last; /* See below */
 
     int i;
@@ -91,7 +91,7 @@ void yf_list_destroy(struct yf_list * list, int free_elements) {
         block = block->next;
         if (free_elements) {
             for (i = 0; i < last->numfull; i++) {
-                free(last->data[i]);
+                yf_free(last->data[i]);
             }
         }
         yf_free(last);

--- a/src/util/platform.h
+++ b/src/util/platform.h
@@ -1,0 +1,35 @@
+#ifndef UTIL_SYSTEM_H
+#define UTIL_SYSTEM_H
+
+#define YF_PLATFORMID_UNKNOWN 0
+#define YF_PLATFORMID_UNIX 1
+#define YF_PLATFORMID_WINNT 2
+#define YF_PLATFORMID_LINUX 3
+#define YF_PLATFORMID_APPLE 4
+#define YF_PLATFORMID_BSD 5
+
+#if defined(__unix__) || defined(__APPLE_CC__)
+#define YF_PLATFORM_UNIX
+#define YF_PLATFORM YF_PLATFORMID_UNIX
+
+#if defined(__linux) || defined(linux) || defined(__linux__)
+#define YF_SUBPLATFORM YF_PLATFORMID_LINUX
+#elif defined(__APPLE__) || defined(macintosh) || defined(__MACH__)
+#define YF_SUBPLATFORM YF_PLATFORMID_APPLE
+#elif defined(__DragonFly__) || defined(__FreeBSD) || defined(__NETBSD__) || defined(__OpenBSD__)
+#define YF_SUBPLATFORM YF_PLATFORMID_BSD
+#else
+#define YF_SUBPLATFORM YF_PLATFORMID_UNIX
+#endif
+
+#elif defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#define YF_PLATFORM_WINNT
+#define YF_PLATFORM YF_PLATFORMID_WINNT
+#define YF_SUBPLATFORM YF_PLATFORMID_WINNT
+#else
+#define YF_PLATFORM_UNKNOWN
+#define YF_PLATFORM YF_PLATFORMID_UNKNOWN
+#define YF_SUBPLATFORM YF_PLATFORMID_UNKNOWN
+#endif
+
+#endif /* UTIL_SYSTEM_H */


### PR DESCRIPTION
This will allow for greater flexibility and error-proness. It also allows to collect output from commands.
In `compiler_backend.c`, change `DUMP_COMMANDS` macro to see compiler invocations.