### PR TITLE
Fix cmdline writing implementation on Windows

### DIFF
--- a/src/driver/os.c
+++ b/src/driver/os.c
@@ -113,7 +113,7 @@ static const size_t cmdline_buffer_size = 256;
 static void ArgvToCommandLine(char * buffer, const char * const args[])
 {
     const char * buffer_end = buffer + cmdline_buffer_size;
-    for (const char * s = *args; s; ++args)
+    for (const char * s; (s = *args); ++args)
     {
         const char * const sbeg = s;
         size_t s_len = strlen(s);
@@ -139,7 +139,8 @@ static void ArgvToCommandLine(char * buffer, const char * const args[])
         }
         for (const char * p = s; p != send; ++p)
             *buffer++ = *p;
-        EscapeBackslashes(&buffer, send - 1, sbeg);
+        if (sbeg != send)
+            EscapeBackslashes(&buffer, send - 1, sbeg);
         *buffer++ = '"';
         *buffer++ = ' ';
     }


### PR DESCRIPTION
Fixes a small programming error that caused the writer to enter an infinite loop (equivalent fix will appear in chirpc soon).
Also fixes a less severe bug that underflows the string when the argument is empty (which may cause undesired effect if the byte before the null byte happens to be a `\`).

Both implementations were tested for various cases with address sanitizer on, so this _shouldn't_ have any more bugs.