### PR TITLE
Rename syntax tree enums to lower the chance of introducing typos. Close #71

### DIFF
--- a/src/api/abstract-tree.h
+++ b/src/api/abstract-tree.h
@@ -25,8 +25,8 @@ struct yfa_value {
      * (like 2 or 57).
      */
     enum yfav_type {
-        YFA_IDENT,
-        YFA_LITERAL,
+        YFA_V_IDENT,
+        YFA_V_LITERAL,
     } type;
 
     /**
@@ -39,8 +39,8 @@ struct yfa_value {
         struct yf_sym * identifier;
         struct {
             enum yfa_lit_type {
-                YFAL_NUM,
-                YFAL_BOOL,
+                YFA_L_NUM,
+                YFA_L_BOOL,
             } type;
             union {
                 int val;
@@ -75,9 +75,9 @@ struct yfa_expr {
     } as;
 
     enum {
-        YFA_VALUE,
-        YFA_BINARY,
-        YFA_FUNCCALL,
+        YFA_E_VALUE,
+        YFA_E_BINARY,
+        YFA_E_FUNCCALL,
     } type;
     
 };

--- a/src/api/cleanup.c
+++ b/src/api/cleanup.c
@@ -47,15 +47,15 @@ void yf_cleanup_anode(struct yf_ast_node * node, int free_node) {
 void yf_cleanup_aexpr(struct yfa_expr * node) {
     struct yf_ast_node * anode;
     switch (node->type) {
-    case YFA_VALUE:
+    case YFA_E_VALUE:
         break;
-    case YFA_BINARY:
+    case YFA_E_BINARY:
         yf_cleanup_aexpr(node->as.binary.left);
         yf_free(node->as.binary.left);
         yf_cleanup_aexpr(node->as.binary.right);
         yf_free(node->as.binary.right);
         break;
-    case YFA_FUNCCALL: {
+    case YFA_E_FUNCCALL: {
         YF_LIST_FOREACH(node->as.call.args, anode) {
             if (anode)
                 yf_cleanup_anode(anode, 1);
@@ -163,13 +163,13 @@ void yf_cleanup_cnode(struct yf_parse_node * node, int free_node) {
 void yf_cleanup_cexpr(struct yfcs_expr * node) {
     struct yf_parse_node * cnode;
     switch (node->type) {
-    case YFCS_VALUE:
+    case YFCS_E_VALUE:
         break;
-    case YFCS_BINARY:
+    case YFCS_E_BINARY:
         yf_cleanup_cnode(node->binary.left, 1);
         yf_cleanup_cnode(node->binary.right, 1);
         break;
-    case YFA_FUNCCALL: {
+    case YFCS_E_FUNCCALL: {
         YF_LIST_FOREACH(node->call.args, cnode) {
             if (cnode)
                 yf_cleanup_cnode(cnode, 1);

--- a/src/api/compilation-data.h
+++ b/src/api/compilation-data.h
@@ -111,7 +111,7 @@ struct yf_compilation_data {
      * Holds additional references that will be cleaned
      * @item_type ?
      */
-     struct yf_list garbage;
+    struct yf_list garbage;
 
 };
 

--- a/src/api/concrete-tree.h
+++ b/src/api/concrete-tree.h
@@ -46,8 +46,8 @@ struct yfcs_literal {
 struct yfcs_value {
 
     enum {
-        YFCS_IDENT,
-        YFCS_LITERAL,
+        YFCS_V_IDENT,
+        YFCS_V_LITERAL,
     } type;
 
     union {
@@ -85,9 +85,9 @@ struct yfcs_expr {
     };
 
     enum {
-        YFCS_VALUE,
-        YFCS_BINARY,
-        YFCS_FUNCCALL,
+        YFCS_E_VALUE,
+        YFCS_E_BINARY,
+        YFCS_E_FUNCCALL,
     } type;
     
 };

--- a/src/api/cst-dump.c
+++ b/src/api/cst-dump.c
@@ -147,8 +147,8 @@ static void yf_dump_expr(struct yfcs_expr * node, FILE * out) {
     indent();
 
     switch (node->type) {
-    case YFCS_VALUE:
-        if (node->value.type != YFCS_IDENT)
+    case YFCS_E_VALUE:
+        if (node->value.type != YFCS_V_IDENT)
             yf_print_line(out, "value: %s",
                 node->value.literal.value
             );
@@ -157,7 +157,7 @@ static void yf_dump_expr(struct yfcs_expr * node, FILE * out) {
                 node->value.identifier.filepath, node->value.identifier.name
             );
         break;
-    case YFCS_BINARY:
+    case YFCS_E_BINARY:
         yf_print_line(out,
             "operator: %s", get_op_string(node->binary.op)
         );
@@ -166,7 +166,7 @@ static void yf_dump_expr(struct yfcs_expr * node, FILE * out) {
         yf_print_line(out, "right:");
         yf_dump_expr(&node->binary.right->expr, out);
         break;
-    case YFCS_FUNCCALL:
+    case YFCS_E_FUNCCALL:
         yf_print_line(
             out, "function name: %s::%s",
             node->call.name.filepath, node->call.name.name

--- a/src/api/sym.h
+++ b/src/api/sym.h
@@ -17,9 +17,9 @@
  * What 'kind' of number does a primitive type represent?
  */
 enum yfpt_format {
-    YFS_INT, /* NOT just "int", but a whole number. */
-    YFS_FLOAT, /* ANY number with a decimal part. */
-    YFS_NONE,
+    YFS_F_INT, /* NOT just "int", but a whole number. */
+    YFS_F_FLOAT, /* ANY number with a decimal part. */
+    YFS_F_NONE,
 };
 
 struct yfs_primitive_type {
@@ -36,7 +36,7 @@ struct yfs_type {
     };
 
     enum {
-        YFST_PRIMITIVE,
+        YFS_T_PRIMITIVE,
     } kind;
 
     char * name; /* Name of the type */

--- a/src/driver/compile.c
+++ b/src/driver/compile.c
@@ -364,7 +364,7 @@ static int yf_compile_project(struct yf_args * args, struct yf_compilation_data 
 }
 
 static int yf_compile_files(struct yf_args * args, struct yf_compilation_data * compilation) {
-    
+
     struct yf_project_compilation_data data;
     struct yf_compilation_unit_info * fdata;
     int i;

--- a/src/gen/gen.c
+++ b/src/gen/gen.c
@@ -138,12 +138,12 @@ static void yf_gen_expr(
     fprintf(out, "(");
 
     switch (node->type) {
-        case YFA_VALUE:
+        case YFA_E_VALUE:
             switch (node->as.value.type) {
-                case YFA_LITERAL:
+                case YFA_V_LITERAL:
                     fprintf(out, "%d", node->as.value.as.literal.val);
                     break;
-                case YFA_IDENT:
+                case YFA_V_IDENT:
                     fprintf(
                         out, "%s$$%s",
                         i->gen_prefix,
@@ -152,12 +152,12 @@ static void yf_gen_expr(
                     break;
             }
             break;
-        case YFA_BINARY:
+        case YFA_E_BINARY:
             yf_gen_expr(node->as.binary.left, out, i);
             fprintf(out, " %s ", get_op_string(node->as.binary.op));
             yf_gen_expr(node->as.binary.right, out, i);
             break;
-        case YFA_FUNCCALL:
+        case YFA_E_FUNCCALL:
             fprintf(
                 out, "%s$$%s(",
                 i->gen_prefix, node->as.call.name->fn.name

--- a/src/gen/typegen.c
+++ b/src/gen/typegen.c
@@ -6,13 +6,13 @@
 
 int yfg_ctype(int len, char * buf, struct yfs_type * type) {
 
-    if (type->kind != YFST_PRIMITIVE) {
+    if (type->kind != YFS_T_PRIMITIVE) {
         return -1; /* No can do */
     }
 
     if (type->primitive.size >= 8) {
         /* Because stdint is #include'd, we can just print int[blank]_t. */
-        if (type->primitive.type == YFS_INT) {
+        if (type->primitive.type == YFS_F_INT) {
             snprintf(
                 buf, len, "int%d_t",
                 type->primitive.size

--- a/src/parser/expr.c
+++ b/src/parser/expr.c
@@ -40,7 +40,7 @@ int yfp_atomic_expr(struct yf_parse_node * node, struct yf_lexer * lexer) {
         /* If it's an opening paren, we have a funccall: [identifier] "(" [...
          * ... */
         if (tok.type == YFT_OPAREN) {
-            node->expr.type = YFCS_FUNCCALL;
+            node->expr.type = YFCS_E_FUNCCALL;
             memcpy(
                 &node->expr.call.name,
                 &ident,
@@ -49,8 +49,8 @@ int yfp_atomic_expr(struct yf_parse_node * node, struct yf_lexer * lexer) {
             return yfp_funccall(node, lexer);
         } else {
             /* No we don't. */
-            node->expr.type = YFCS_VALUE;
-            node->expr.value.type = YFCS_IDENT;
+            node->expr.type = YFCS_E_VALUE;
+            node->expr.value.type = YFCS_V_IDENT;
             memcpy(
                 &node->expr.value.identifier,
                 &ident,
@@ -59,11 +59,11 @@ int yfp_atomic_expr(struct yf_parse_node * node, struct yf_lexer * lexer) {
         }
         break;
     case YFT_LITERAL:
-    node->expr.type = YFCS_VALUE;
+    node->expr.type = YFCS_E_VALUE;
         strcpy(
             node->expr.value.literal.value, tok.data
         );
-        node->expr.value.type = YFCS_LITERAL;
+        node->expr.value.type = YFCS_V_LITERAL;
         break;
     case YFT_OPAREN:
         if (yfp_expr(node, lexer, 0, NULL))
@@ -180,7 +180,7 @@ static int yfp_sort_expr_tree(
         return 0;
     }
     if (num_nodes == 2) {
-        node->type = YFCS_BINARY;
+        node->type = YFCS_E_BINARY;
         node->binary.op = operators[0];
         node->binary.left = yf_malloc(sizeof(struct yf_parse_node));
         node->binary.right = yf_malloc(sizeof(struct yf_parse_node));
@@ -213,7 +213,7 @@ static int yfp_sort_expr_tree(
     n_node->loc = operator_lines[index];
 
     /* Now that we have our splitting location, we recurse. */
-    node->type = YFCS_BINARY;
+    node->type = YFCS_E_BINARY;
     node->binary.left = yf_malloc(sizeof(struct yf_parse_node));
     node->binary.right = yf_malloc(sizeof(struct yf_parse_node));
     if (!node->binary.left || !node->binary.right) {

--- a/src/semantics/types.c
+++ b/src/semantics/types.c
@@ -14,7 +14,7 @@ enum yfs_conversion_allowedness yfs_is_safe_conversion(
 
     /* User-defined types don't exist yet, and once they do, conversion won't
     exist (for now). */
-    if (from->kind != YFST_PRIMITIVE)
+    if (from->kind != YFS_T_PRIMITIVE)
         return YFS_CONVERSION_INVALID;
 
     f = &from->primitive;
@@ -52,7 +52,7 @@ struct yfs_type * yfse_get_expr_type(
     struct yfa_value * v;
 
     switch (expr->type) {
-    case YFA_BINARY:
+    case YFA_E_BINARY:
 
         ltype = yfse_get_expr_type(expr->as.binary.left, fdata);
         rtype = yfse_get_expr_type(expr->as.binary.right, fdata);
@@ -76,15 +76,15 @@ struct yfs_type * yfse_get_expr_type(
         }
         break;
 
-    case YFA_VALUE:
+    case YFA_E_VALUE:
         v = &expr->as.value;
-        if (v->type == YFA_IDENT) {
+        if (v->type == YFA_V_IDENT) {
             return v->as.identifier->var.dtype;
         } else {
             switch (v->as.literal.type) {
-            case YFAL_NUM:
+            case YFA_L_NUM:
                 return yfv_get_type_s(fdata, "int");
-            case YFAL_BOOL:
+            case YFA_L_BOOL:
                 return yfv_get_type_s(fdata, "bool");
             default:
                 YF_PRINT_ERROR("panic: Unknown literal type");
@@ -92,7 +92,7 @@ struct yfs_type * yfse_get_expr_type(
             }
         }
         break;
-    case YFA_FUNCCALL:
+    case YFA_E_FUNCCALL:
         return expr->as.call.name->fn.rtype;
     }
 

--- a/src/semantics/validate/validate-control.c
+++ b/src/semantics/validate/validate-control.c
@@ -7,12 +7,12 @@ int validate_if(
     struct yfs_type * type,
     int * returns
 ) {
-    
+
     struct yfcs_if * c = &cin->ifstmt;
     struct yfa_if  * a = &ain->ifstmt;
     int if_always_returns = 0, else_always_returns = 0;
     struct yfs_type * t;
-    
+
     ain->type = YFA_IF;
 
     a->cond = yf_malloc(sizeof (struct yf_ast_node));

--- a/src/semantics/validate/validate-expr.c
+++ b/src/semantics/validate/validate-expr.c
@@ -27,7 +27,7 @@ static int validate_value(
     char dig;
 
     /* If an identifier, make sure it actually exists. */
-    if (c->type == YFCS_IDENT) {
+    if (c->type == YFCS_V_IDENT) {
         if (find_symbol(
             validator,
             &a->as.identifier,
@@ -43,15 +43,15 @@ static int validate_value(
             );
             return 1;
         }
-        a->type = YFA_IDENT;
+        a->type = YFA_V_IDENT;
     } else {
 
-        a->type = YFA_LITERAL;
+        a->type = YFA_V_LITERAL;
 
         if (isdigit(c->literal.value[0])) {
 
             /* Parse integer literal */
-            a->as.literal.type = YFAL_NUM;
+            a->as.literal.type = YFA_L_NUM;
             a->as.literal.val = 0;
 
             for (intparse = c->literal.value; *intparse; ++intparse) {
@@ -75,12 +75,12 @@ static int validate_value(
 
         /* Check for 'true' or 'false' */
         if (strcmp(c->literal.value, "true") == 0) {
-            a->as.literal.type = YFAL_BOOL;
+            a->as.literal.type = YFA_L_BOOL;
             a->as.literal.val = 1;
             return 0;
         }
         if (strcmp(c->literal.value, "false") == 0) {
-            a->as.literal.type = YFAL_BOOL;
+            a->as.literal.type = YFA_L_BOOL;
             a->as.literal.val = 0;
             return 0;
         }
@@ -98,14 +98,14 @@ static int validate_binary(
 ) {
     /* First, if it's an assignment, the left side is a variable. */
     if (yfo_is_assign(c->op)) {
-        if (c->left->type != YFCS_VALUE) {
+        if (c->left->expr.type != YFCS_E_VALUE) {
             YF_PRINT_ERROR(
                 "%s %d:%d: Left side of assignment must not be compound",
                 loc->file, loc->line, loc->column
             );
             return 1;
         }
-        if (c->left->expr.value.type != YFCS_IDENT) {
+        if (c->left->expr.value.type != YFCS_V_IDENT) {
             YF_PRINT_ERROR(
                 "%s %d:%d: Left side of assignment must be an identifier",
                 loc->file, loc->line, loc->column
@@ -278,16 +278,16 @@ static int validate_expr_e(
     /* If this is unary - (just a value), ... */
     switch (c->type) {
 
-    case YFCS_VALUE:
-        a->type = YFA_VALUE;
+    case YFCS_E_VALUE:
+        a->type = YFA_E_VALUE;
         return validate_value(validator, &c->value, &a->as.value, loc);
 
-    case YFCS_BINARY:
-        a->type = YFA_BINARY;
+    case YFCS_E_BINARY:
+        a->type = YFA_E_BINARY;
         return validate_binary(validator, &c->binary, &a->as.binary, loc);
 
-    case YFCS_FUNCCALL:
-        a->type = YFA_FUNCCALL;
+    case YFCS_E_FUNCCALL:
+        a->type = YFA_E_FUNCCALL;
         return validate_funccall(validator, &c->call, &a->as.call, loc);
     }
 

--- a/src/semantics/validate/validate-var.c
+++ b/src/semantics/validate/validate-var.c
@@ -93,7 +93,7 @@ int validate_vardecl(
 
     /* Variables can't have type "void" */
     if (
-        a->name->var.dtype->kind == YFST_PRIMITIVE
+        a->name->var.dtype->kind == YFS_T_PRIMITIVE
         && a->name->var.dtype->primitive.size == 0
     ) {
         YF_PRINT_ERROR(

--- a/src/semantics/validate/validate.c
+++ b/src/semantics/validate/validate.c
@@ -11,7 +11,7 @@ static void add_type(
 
     struct yfs_type * type = yf_malloc(sizeof (struct yfs_type));
     type->primitive.size = size;
-    type->kind = YFST_PRIMITIVE;
+    type->kind = YFS_T_PRIMITIVE;
     type->primitive.type = fmt;
     type->name = name;
     yfv_add_type(udata, type);
@@ -23,24 +23,24 @@ static void yfv_add_builtin_types(struct yf_compile_analyse_job * udata) {
     /* All types are signed for now - unsigned types are not yet supported. */
 
     /* "standard" types. */
-    add_type(udata, "char",        8, YFS_INT  );
-    add_type(udata, "short",      16, YFS_INT  );
-    add_type(udata, "int",        32, YFS_INT  );
-    add_type(udata, "long",       64, YFS_INT  );
-    add_type(udata, "void",        0, YFS_NONE );
-    add_type(udata, "float",      32, YFS_FLOAT);
-    add_type(udata, "double",     64, YFS_FLOAT);
+    add_type(udata, "char",        8, YFS_F_INT  );
+    add_type(udata, "short",      16, YFS_F_INT  );
+    add_type(udata, "int",        32, YFS_F_INT  );
+    add_type(udata, "long",       64, YFS_F_INT  );
+    add_type(udata, "void",        0, YFS_F_NONE );
+    add_type(udata, "float",      32, YFS_F_FLOAT);
+    add_type(udata, "double",     64, YFS_F_FLOAT);
 
     /* Convenience types. */
-    add_type(udata, "i16",        16, YFS_INT  );
-    add_type(udata, "i32",        32, YFS_INT  );
-    add_type(udata, "i64",        64, YFS_INT  );
-    add_type(udata, "f16",        16, YFS_FLOAT);
-    add_type(udata, "f32",        32, YFS_FLOAT);
-    add_type(udata, "f64",        64, YFS_FLOAT);
+    add_type(udata, "i16",        16, YFS_F_INT  );
+    add_type(udata, "i32",        32, YFS_F_INT  );
+    add_type(udata, "i64",        64, YFS_F_INT  );
+    add_type(udata, "f16",        16, YFS_F_FLOAT);
+    add_type(udata, "f32",        32, YFS_F_FLOAT);
+    add_type(udata, "f64",        64, YFS_F_FLOAT);
 
     /* We're considering bool to be one bit for conversion purposes. */
-    add_type(udata, "bool",       1,  YFS_INT  );
+    add_type(udata, "bool",       1,  YFS_F_INT  );
 
 }
 

--- a/src/util/hashmap.c
+++ b/src/util/hashmap.c
@@ -103,7 +103,7 @@ int yfh_remove(struct yf_hashmap * hm, const char * key, void (*cleanup)(void *)
 
 int yfh_remove_at(struct yfh_cursor * cur, void (*cleanup)(void *)) {
 
-    /* We have to backtrack a little because we need to update the previouse pointer */
+    /* We have to backtrack a little because we need to update the previous pointer */
     struct yfh_bucket ** before_ptr;
     struct yfh_bucket * bucket;
 


### PR DESCRIPTION
One example is seen in #71.
I also caught some more examples of this that went unnoticed. Hopefully the explicit names will eliminate the possibility of introducing such type of bug in the future.